### PR TITLE
Formgenerator support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.3.3] - 2021-03-24
+- set maximum dropzone version to 5.7.2, as higher versions currently no compatible
+
 ## [1.3.2] - 2020-09-09
 - updated js dependencies
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "licence": "LGPL-3.0-or-later",
   "dependencies": {
     "@hundh/contao-utils-bundle": "^1.15.0",
-    "dropzone": "^5.1"
+    "dropzone": ">=5.1.0 <5.7.3"
   },
   "devDependencies": {
     "@symfony/webpack-encore": "^0.30",

--- a/src/EventListener/PrepareFormDataListener.php
+++ b/src/EventListener/PrepareFormDataListener.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * Copyright (c) 2020 Heimrich & Hannot GmbH
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace HeimrichHannot\MultiFileUploadBundle\EventListener;
+
+use Contao\FilesModel;
+use Contao\Form;
+use Contao\FormFieldModel;
+use Contao\Validator;
+use HeimrichHannot\MultiFileUploadBundle\Backend\MultiFileUpload;
+use HeimrichHannot\MultiFileUploadBundle\Form\FormMultiFileUpload;
+
+class PrepareFormDataListener
+{
+    /**
+     * @param array|FormFieldModel[] $fields
+     */
+    public function __invoke(array &$submittedData, array $labels, array $fields, Form $form): void
+    {
+//        foreach ($fields as $field) {
+//            if (!'multifileupload' === $field->type || !is_array($submittedData[$field->name])) {
+//                continue;
+//            }
+//            $widget = new FormMultiFileUpload($field->row());
+//            $widget->moveFiles()
+//
+//
+//
+//
+//            $files = FilesModel::findMultipleByUuids($submittedData[$field->name]);
+//            foreach ($submittedData[$field->name] as $value) {
+//                if (!Validator::isUuid($value)) {
+//                    continue;
+//                }
+//                $file = FilesModel::findByUuid($value);
+//                if (!$file) {
+//                    continue;
+//                }
+//                if (!isset($_SESSION['FILES'][$field->name])) {
+//                    $_SESSION['FILES'][$field->name] = [
+//                        "name"     => $file->name,
+//                        "type"     => $file->type,
+//                        "tmp_name" => $file->path,
+//                        "error"    => 0
+//                    ];
+//                }
+//            }
+//            return;
+//        }
+    }
+}

--- a/src/EventListener/ValidateFormFieldListener.php
+++ b/src/EventListener/ValidateFormFieldListener.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Copyright (c) 2020 Heimrich & Hannot GmbH
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace HeimrichHannot\MultiFileUploadBundle\EventListener;
+
+use Contao\Form;
+use Contao\Input;
+use Contao\Widget;
+use HeimrichHannot\MultiFileUploadBundle\Form\FormMultiFileUpload;
+
+class ValidateFormFieldListener
+{
+    public function __invoke(Widget $widget, string $formId, array $formData, Form $form): Widget
+    {
+        if (!($widget instanceof FormMultiFileUpload) || $widget->hasErrors() || !Input::post('FORM_SUBMIT') == $formId) {
+            return $widget;
+        }
+//        $widget->moveFiles()
+
+//        if ('myform' === $formId && $widget instanceof \Contao\FormTextField && 'mywidget' === $widget->name) {
+//            // Do your custom validation and add an error if widget does not validate
+        ////            if (!$this->validateWidget($widget)) {
+        ////                $widget->addError('My custom widget error');
+        ////            }
+//        }
+
+        return $widget;
+    }
+}

--- a/src/Resources/assets/js/contao-multifileupload-bundle.js
+++ b/src/Resources/assets/js/contao-multifileupload-bundle.js
@@ -7,8 +7,6 @@ import '../scss/dropzone.scss';
 // // Disabling autoDiscover, otherwise Dropzone will try to attach twice.
 Dropzone.autoDiscover = false;
 
-// import {utilsBundle} from '@hundh/contao-utils-bundle';
-
 class ContaoMultifileuploadBundle
 {
     /**

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -1,45 +1,43 @@
 <?php
-/**
- * Contao Open Source CMS
+
+/*
+ * Copyright (c) 2020 Heimrich & Hannot GmbH
  *
- * Copyright (c) 2015 Heimrich & Hannot GmbH
- *
- * @package multifileupload
- * @author  Rico Kaltofen <r.kaltofen@heimrich-hannot.de>
- * @license http://www.gnu.org/licences/lgpl-3.0.html LGPL
+ * @license LGPL-3.0-or-later
  */
 
-
-/**
+/*
  * Front end form fields
  */
 $GLOBALS['TL_FFL']['multifileupload'] = \HeimrichHannot\MultiFileUploadBundle\Form\FormMultiFileUpload::class;
 $GLOBALS['BE_FFL']['multifileupload'] = \HeimrichHannot\MultiFileUploadBundle\Widget\BackendMultiFileUpload::class;
 
-/**
+/*
  * Hooks
  */
 $GLOBALS['TL_HOOKS']['executePostActions']['multifileupload'] = ['huh.multifileupload.listener.hooks', 'executePostActionsHook'];
 $GLOBALS['TL_HOOKS']['getAttributesFromDca']['huh_multifileupload'] = [\HeimrichHannot\MultiFileUploadBundle\EventListener\GetAttributesFromDcaListener::class, 'onGetAttributesFromDca'];
+$GLOBALS['TL_HOOKS']['prepareFormData']['huh_multifileupload'] = [\HeimrichHannot\MultiFileUploadBundle\EventListener\PrepareFormDataListener::class, '__invoke'];
+$GLOBALS['TL_HOOKS']['validateFormField']['huh_multifileupload'] = [\HeimrichHannot\MultiFileUploadBundle\EventListener\ValidateFormFieldListener::class, '__invoke'];
 
-/**
+/*
  * Ajax action
  */
 $GLOBALS['AJAX'][\HeimrichHannot\MultiFileUploadBundle\Backend\MultiFileUpload::NAME] = [
     'actions' => [
         \HeimrichHannot\MultiFileUploadBundle\Backend\MultiFileUpload::ACTION_UPLOAD => [
-            'arguments'       => [],
-            'optional'        => [],
+            'arguments' => [],
+            'optional' => [],
             'csrf_protection' => true, // cross-site request forgery (ajax token check)
         ],
     ],
 ];
 
-/**
+/*
  * Assets (add dropzone not within contao files manager)
  */
 $GLOBALS['TL_COMPONENTS']['multifileupload'] = [
-    'js'  => [
+    'js' => [
         'bundles/heimrichhannotcontaomultifileupload/assets/dropzone.js|static',
         'bundles/heimrichhannotcontaomultifileupload/assets/contao-multifileupload-bundle.js|static',
     ],


### PR DESCRIPTION
**State:** Draft - no not merge!

This pull request should lead to better form generator support.

Currently the file is not correctly resolved and also not moved with FormMultiFileUpload::moveFile(), as there is no dca context. I think this must be resolved in the validateFormField hook, but that needs refactoring to support non-dca-context.

