### PR TITLE
Add support to configure allowed mime types

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ thumbnailHeight | 90 | The thumbnail height (in px) of the uploaded file preview
 labels | array() | Overwrite the head and body labels within the upload field.
 skipDeleteAfterSubmit | false | Prevent file removal from filesystem.
 hideLabel | false | Hide widget label (Frontend)
+mimeTypes | `null` | A comma separated list of allowed mime types (e.g. `'application/x-compressed,application/x-zip-compressed,application/zip,multipart/x-zip'`). Set to empty string `''` if you don't want to restrict mime types. Set to `null` if you just want to restrict mime types if they differ while automatic detection.
 
 
 ### Field Callbacks

--- a/src/Form/FormMultiFileUpload.php
+++ b/src/Form/FormMultiFileUpload.php
@@ -527,6 +527,18 @@ class FormMultiFileUpload extends Upload
      */
     protected function validateMimeType($mimeClient, $mimeDetected)
     {
+        $allowedMimeTypes = null !== $this->mimeTypes ? StringUtil::trimsplit(',', $this->mimeTypes) : null;
+
+        if (\is_array($allowedMimeTypes)) {
+            if (empty($allowedMimeTypes)) {
+                return true;
+            }
+            if (\in_array($mimeDetected, $allowedMimeTypes, true)) {
+                return true;
+            }
+            return false;
+        }
+
         if ($mimeClient !== $mimeDetected) {
             // allow safe mime types
             switch ($mimeDetected) {


### PR DESCRIPTION
At the moment it is not possible to configure allowed mime types.
This is especially a problem, if they differ while automatic detection!