### PR TITLE
Fix: hook causes problems with manipulated data

### DIFF
--- a/src/EventListener/Contao/FormGeneratorListener.php
+++ b/src/EventListener/Contao/FormGeneratorListener.php
@@ -33,6 +33,11 @@ class FormGeneratorListener
                 continue;
             }
 
+            if (!is_array($submittedData[$fileData['field']])) {
+                unset($submittedData[$fileData['field']]);
+                break;
+            }
+
             if (isset($submittedData[$fileData['field']][$fileData['key']])) {
                 unset($submittedData[$fileData['field']][$fileData['key']]);
             }


### PR DESCRIPTION
If the processFormData hook is triggered and `$submittedData` has previously been manipulated, e.g. by the contao-form-type-bundle, a fatal error can occur.

```php
// $fileData['field'] = field name
// $fileData['key'] = 0
// $submittedData[$fileData['field']] = 16 bytes file id

if (isset($submittedData[$fileData['field']][$fileData['key']])) { // evaluates to true!
    unset($submittedData[$fileData['field']][$fileData['key']]); // throws error
}
```

Therefore, we need to check not only if the key isset, but also if we're dealing with an array.

```php
if (!is_array($submittedData[$fileData['field']])) {
    unset($submittedData[$fileData['field']]);
    break;
}

// ... code from above goes here
```